### PR TITLE
pluralised pack author in shortcuts doc

### DIFF
--- a/docs/integrating/shortcuts.mdx
+++ b/docs/integrating/shortcuts.mdx
@@ -7,7 +7,7 @@ The name of the shortcuts will be determined by the `--packTitle` vpk argument. 
 You can specify where you'd like shortcuts to be created by using the `--shortcuts {locations}` command line argument. The following locations are supported:
 - `Desktop`
 - `StartMenuRoot`
-- `StartMenu` (this is a subfolder in the StartMenuRoot, must also specify `--packAuthor`)
+- `StartMenu` (this is a subfolder in the StartMenuRoot, must also specify `--packAuthors`)
 - `Startup`
 - `None` (to disable shortcut creation)
 


### PR DESCRIPTION
quick fix, but it was annoying me.

packAuthor is no longer a command, as it is now plural