### PR TITLE
Rename Azure Trusted Signing to Azure Artifact Signing

### DIFF
--- a/docs/packaging/signing.mdx
+++ b/docs/packaging/signing.mdx
@@ -14,16 +14,16 @@ Here is the general rule of thumb for Windows Defender/Smart Screen warnings:
 
 ### Acquiring a code signing certificate
 
-#### Azure Trusted Signing
+#### Azure Artifact Signing
 
-As of April 2024, the most effective way to code-sign your product is via [**Azure Trusted Signing (ATS)**](https://azure.microsoft.com/en-us/products/trusted-signing).
+As of April 2024, the most effective way to code-sign your product is via [**Azure Artifact Signing**](https://azure.microsoft.com/en-us/products/artifact-signing) (formerly known as Azure Trusted Signing).
 
 - Costs USD$10/mo (or USD$120/yr) which is on-par or cheaper than code signing certificates from other issuers.
 - Full cloud solution / Does not require any physical hardware (HSM) shipped to you.
 - Signing can be automated (eg. in your CI pipeline)
-- ATS certificates get built-in instant reputation for smart-screen and defender.
+- Artifact Signing certificates get built-in instant reputation for smart-screen and defender.
 
-ATS can be used with by following the [Microsoft documentation for using ATS with signtool.exe](https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations#download-and-install-net-80-runtime), and then reading our docs below on how to configure signtool.exe with Velopack.
+Artifact Signing can be used by following the [Microsoft documentation for using Artifact Signing with signtool.exe](https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations#download-and-install-net-80-runtime), and then reading our docs below on how to configure signtool.exe with Velopack.
 
 #### Other certificate vendors
 
@@ -43,32 +43,32 @@ There are also resellers which may have certificates from authorised issuers for
 Note that since June 1, 2023 there [has been a policy change](https://knowledge.digicert.com/general-information/new-private-key-storage-requirement-for-standard-code-signing-certificates-november-2022), meaning it is no longer possible to download your code signing certificate. It must be either stored in an authorised cloud HSM or a USB HSM will be shipped to you. Many of these solutions will require manual steps and not be compatible with automation / CI. Please review carefully before purchasing.
 :::
 
-### Signing via Azure Trusted Signing
+### Signing via Azure Artifact Signing
 
-[Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/overview) is a managed signing service from Microsoft and one of the most [cost effective](https://azure.microsoft.com/products/trusted-signing#pricing) ways to sign your application.
+[Azure Artifact Signing](https://learn.microsoft.com/azure/trusted-signing/overview) (formerly Trusted Signing) is a managed signing service from Microsoft and one of the most [cost effective](https://azure.microsoft.com/en-us/pricing/details/artifact-signing) ways to sign your application.
 
-For detailed information on Azure Trusted Signing please refer to the [official documentation](https://learn.microsoft.com/azure/trusted-signing/).
+For detailed information on Azure Artifact Signing please refer to the [official documentation](https://learn.microsoft.com/azure/trusted-signing/).
 
 :::note
 Signing relies on `signtool.exe` which is only supported on Windows. If you are using a different operating system, you will need to sign your binaries on a Windows machine before deploying them.
 :::
 
-1. First you will need to create an Azure account at: https://azure.microsoft.com/pricing/purchase-options/azure-account?icid=trusted-signing. This account will need to have an [active subscription](https://learn.microsoft.com/azure/cost-management-billing/manage/create-subscription#create-a-subscription).
-0. Register the Azure Trusted Signing [resource provider](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types). This can be done either in the Azure portal, or via the Azure CLI by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#register-the-trusted-signing-resource-provider).
-0. Create the Azure Trusted Signing resource by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#create-a-trusted-signing-account). Note the name and region that you select, as you will use these values later for the `CodeSigningAccountName` and `Endpoint` values respectively, in the signing configuration JSON file.
+1. First you will need to create an Azure account at: https://azure.microsoft.com/pricing/purchase-options/azure-account. This account will need to have an [active subscription](https://learn.microsoft.com/azure/cost-management-billing/manage/create-subscription#create-a-subscription).
+0. Register the Azure Artifact Signing [resource provider](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types). This can be done either in the Azure portal, or via the Azure CLI by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#register-the-trusted-signing-resource-provider).
+0. Create the Azure Artifact Signing resource by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#create-a-trusted-signing-account). Note the name and region that you select, as you will use these values later for the `CodeSigningAccountName` and `Endpoint` values respectively, in the signing configuration JSON file.
 0. Create an identity validation request by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#create-an-identity-validation-request). This step must be done in the Azure Portal. The identity validation can either be done for an Organization or an Individual developer. This process make take a while as the identity information is verified by Microsoft. Return to these steps after the identity validation process is completed.
 0. Create a certificate profile by following [these instructions](https://learn.microsoft.com/azure/trusted-signing/quickstart?tabs=registerrp-portal%2Caccount-portal%2Corgvalidation%2Ccertificateprofile-portal%2Cdeleteresources-portal#create-a-certificate-profile). There are multiple [trust models](https://learn.microsoft.com/azure/trusted-signing/concept-trusted-signing-trust-models) that are supported. The Public Trust model is the most common and is suitable for most applications. Note the name of the certificate profile as you will use this value later as the `CertificateProfileName` in the signing configuration JSON file.
-0. Velopack comes bundled with a version of [signtool.exe](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-signtool) (x64) and the [dlib package](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-the-trusted-signing-dlib-package) that is compatible with Azure Trusted Signing. These components [require the .NET 8.0 Runtime](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-net-80-runtime) be installed on the machine that will be performing the signing. You can find the latest version of the .NET 8.0 runtime [here](https://dotnet.microsoft.com/download/dotnet/8.0).
-0. Setup authentication with Azure Trusted Signing. `signtool.exe` leverages the common [DefaultAzureCredentials](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) class for authenticating with Azure. This class supports authenticating in a variety of ways, including the Azure CLI. After installing the Azure CLI, run `az login`. This will provide signtool.exe the authentication it needs when `vpk` invokes it. If you are running inside of the [GitHub Actions](https://github.com/marketplace/actions/azure-cli-action) or [Azure DevOps](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines) there is built in support that handles performing the needed authentication.
+0. Velopack comes bundled with a version of [signtool.exe](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-signtool) (x64) and the [dlib package](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-the-trusted-signing-dlib-package) that is compatible with Azure Artifact Signing. These components [require the .NET 8.0 Runtime](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#download-and-install-net-80-runtime) be installed on the machine that will be performing the signing. You can find the latest version of the .NET 8.0 runtime [here](https://dotnet.microsoft.com/download/dotnet/8.0).
+0. Setup authentication with Azure Artifact Signing. `signtool.exe` leverages the common [DefaultAzureCredentials](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet) class for authenticating with Azure. This class supports authenticating in a variety of ways, including the Azure CLI. After installing the Azure CLI, run `az login`. This will provide signtool.exe the authentication it needs when `vpk` invokes it. If you are running inside of the [GitHub Actions](https://github.com/marketplace/actions/azure-cli-action) or [Azure DevOps](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/azure-cli-v2?view=azure-pipelines) there is built in support that handles performing the needed authentication.
 0. Create signing metadata JSON file. This file has three required paramters and an optional CorrelationId. The file should look like this:
    ```json
    {
-     "Endpoint": "<Trusted Signing account endpoint>",
-     "CodeSigningAccountName": "<Trusted Signing account name>",
+     "Endpoint": "<Artifact Signing account endpoint>",
+     "CodeSigningAccountName": "<Artifact Signing account name>",
      "CertificateProfileName": "<Certificate profile name>"
    }
    ```
-   The values from each of these can be found in the steps above where you created the Azure Trusted Signing resource, and the certificate profile. The file should be saved with UTF-8 (without a BOM) encoding. Though not required, this is often named as `metadata.json`. The full details can be seen [here](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#create-a-json-file).
+   The values from each of these can be found in the steps above where you created the Azure Artifact Signing resource, and the certificate profile. The file should be saved with UTF-8 (without a BOM) encoding. Though not required, this is often named as `metadata.json`. The full details can be seen [here](https://learn.microsoft.com/azure/trusted-signing/how-to-signing-integrations#create-a-json-file).
 0. Pass the metadata JSON file. When calling `vpk pack` using `--azureTrustedSignFile <path to json file>`. `vpk` will pass the file through to `signtool.exe` to sign the needed assets.
 
 ### Signing via `signtool.exe`
@@ -110,7 +110,7 @@ The above will sign one file at a time, but if your signing tool supports batch 
 [JSign](https://ebourg.github.io/jsign/) is a versatile code signing tool that runs on Linux, macOS and Windows. It supports a wide range of signing algorithms and timestamping services.
 
 To use it with Velopack do the following:
-1. Follow the steps abose to setup [Azure Trusted Signing](#signing-via-azure-trusted-signing)
+1. Follow the steps above to setup [Azure Artifact Signing](#signing-via-azure-artifact-signing)
 0. Download the latest version of JSign from https://ebourg.github.io/jsign/#files
 0. Install the [Azure CLI](https://learn.microsoft.com/cli/azure/) and login with `az login`
 0. Get an [access token](https://learn.microsoft.com/cli/azure/account?view=azure-cli-latest#az-account-get-access-token) by running `az account get-access-token --resource https://codesigning.azure.net`


### PR DESCRIPTION
Microsoft has rebranded **Azure Trusted Signing** to **Azure Artifact Signing**. This PR updates the signing documentation to reflect the new name so users aren't confused by stale branding when following the setup guide.

### Approach

All references in `docs/packaging/signing.mdx` have been updated:

- Headings and body text renamed from "Azure Trusted Signing" → "Azure Artifact Signing"
- Product URLs updated to the new `artifact-signing` paths (product page, pricing page)
- JSON metadata placeholder comments updated (`Artifact Signing account endpoint/name`)
- "(formerly Trusted Signing)" parentheticals added on first mentions for discoverability
- Internal anchor link updated to match the new heading slug
- Fixed a small pre-existing typo ("abose" → "above") in an adjacent line

### What was intentionally left unchanged

- **MS Learn documentation URLs** (`learn.microsoft.com/azure/trusted-signing/...`) — these still resolve correctly and are controlled by Microsoft
- **`docs/reference/cli/content/vpk-windows.mdx`** — this file is auto-generated from the CLI source and should not be manually edited
- **CLI flag names** (`--azureTrustedSignFile`) — these are part of the Velopack CLI API and would be a breaking change