### PR TITLE
Fix outdated build instructions in compiling docs

### DIFF
--- a/docs/contributing/compiling.mdx
+++ b/docs/contributing/compiling.mdx
@@ -10,15 +10,15 @@ It is made up of:
 In order to test the project, you need to build the Rust binaries before compiling dotnet.   
 
 ### Prerequisites
- - [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
  - [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
  - [Rust / Cargo](https://www.rust-lang.org/tools/install)
  - `dotnet tool install -g dotnet-coverage`
  - `dotnet tool install -g nbgv`
 
 ### Debug / Test
-On windows, you need to build the Rust binaries using the `windows` feature before running tests. On OSX, you should run `cargo build` instead. 
+On Windows, you need to build the Rust binaries using the `windows` feature before running tests. On OSX or Linux, you should run `cargo build` without the feature flag instead. 
 
+On Windows:
 ```shell
 git clone https://github.com/velopack/velopack.git
 cd velopack/src/bins
@@ -28,24 +28,55 @@ dotnet build
 dotnet test --no-build
 ```
 
-### Release / Build
-This is slightly complicated, because you will need to compile Rust on x64 OSX and x64 Windows before creating the final packages.
-
-On OSX:
+On OSX / Linux:
 ```shell
 git clone https://github.com/velopack/velopack.git
 cd velopack/src/bins
-cargo build --release
+cargo build
+cd ../../
+dotnet build
+dotnet test --no-build
 ```
+
+### Release / Build
+Creating a full production release is complex because Velopack must include native binaries for Windows, Linux, and macOS. You need to build the Rust binaries separately on each platform, then combine them on the final build machine using `/p:PackRustAssets=true`.
+
+For **local development**, you typically only need binaries for your current OS. The simplest approach is:
 
 On Windows:
 ```shell
 git clone https://github.com/velopack/velopack.git
 cd velopack/src/bins
 cargo build --release --features windows
-copy {path_to_osx_update} target/release/updatemac
-dotnet build -c Release /p:PackRustAssets=true
+cd ../../
+dotnet build -c Release
 ```
+
+On OSX:
+```shell
+git clone https://github.com/velopack/velopack.git
+cd velopack/src/bins
+cargo build --release
+cd ../../
+dotnet build -c Release
+```
+
+On Linux:
+```shell
+git clone https://github.com/velopack/velopack.git
+cd velopack/src/bins
+cargo build --release
+cd ../../
+dotnet build -c Release
+```
+
+:::tip
+For a complete working example of building a release using local Velopack code, see the [dev-scripts in the Avalonia sample](https://github.com/velopack/velopack/tree/master/samples/CSharpAvalonia/dev-scripts).
+:::
+
+:::note
+A full **cross-platform production build** (combining binaries from all operating systems into one package) requires building Rust on each platform first, then running `dotnet build -c Release /p:PackRustAssets=true` with all platform binaries present. This workflow is handled by CI and is not practical to replicate locally. See the [CI workflows](https://github.com/velopack/velopack/tree/master/.github/workflows) for details.
+:::
 
 ### Preparing Linux
 If you are on Linux (tested on Ubuntu), there are additional package pre-requisites:
@@ -56,7 +87,6 @@ sudo apt install libssl-dev pkg-config build-essential
 Installing dotnet and setting up the paths are a pain, I recommend using the [dotnet-install.sh](https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script) script.
 
 ```shell
-./dotnet-install.sh -c 6.0
 ./dotnet-install.sh -c 8.0
 ```
 
@@ -82,7 +112,7 @@ dotnet could be at a different location (eg. `/usr/share/dotnet`) and the paths 
 
 Once dotnet is configured, you can Install Rust, typically done with the [rustup script available here](https://www.rust-lang.org/tools/install)
 
-To verify that Rust is installed and working correctly, you should compile the Rust binaries in `src/Rust`:
+To verify that Rust is installed and working correctly, you should compile the Rust binaries in `src/bins`:
 
 ```shell
 cargo build --target x86_64-unknown-linux-gnu --release


### PR DESCRIPTION
The `docs/contributing/compiling.mdx` page had several outdated and confusing instructions, as reported in #35. Most notably, the Release/Build section told Windows users to run `copy {path_to_osx_update} target/release/updatemac` with no explanation of what that meant or where the file comes from. The maintainer confirmed the compiling docs were out of date.

### Changes

- **Removed the confusing `copy {path_to_osx_update}` command** — this was the core pain point from the issue
- **Rewrote Release/Build section** — separates local dev builds (simple per-OS commands) from production cross-platform builds, with links to the [Avalonia sample dev-scripts](https://github.com/velopack/velopack/tree/master/samples/CSharpAvalonia/dev-scripts) and [CI workflows](https://github.com/velopack/velopack/tree/master/.github/workflows) for reference
- **Added OSX/Linux commands** to the Debug/Test section (previously only showed Windows commands)
- **Updated prerequisites** — removed .NET 6 SDK (projects now target net8.0)
- **Fixed `src/Rust` → `src/bins`** directory reference in the Linux section
- **Updated Linux `dotnet-install.sh`** to only install .NET 8

All commands were verified against the current CI pipelines (`build-rust.yml`, `build-tests.yml`, `build-packages.yml`) and the Avalonia sample dev-scripts.

Fixes #35