### PR TITLE
Add account management documentation

### DIFF
--- a/docs/distributing/Flow/account.mdx
+++ b/docs/distributing/Flow/account.mdx
@@ -1,0 +1,35 @@
+---
+sidebar_label: Account Management
+sidebar_position: 5
+---
+
+# Account Management
+
+## Account Settings
+
+To access your account settings in the <FlowLink /> dashboard, click your profile avatar or username in the top-right corner and select **Account Settings**. From here you can update your display name, email address, and manage security options such as connected OAuth providers.
+
+## Deleting Your Account
+
+To permanently delete your account, navigate to **Account Settings** and scroll to the **Danger Zone** section, then click **Delete Account**.
+
+Before your account can be deleted, the following prerequisites must be met:
+
+### Remove Projects from Owned Teams
+
+If you are the **Owner** of any team that contains projects, you must delete all projects from those teams before your account can be deleted. Navigate to each team, open each project, and delete it from the project settings page.
+
+### Cancel Active Subscriptions
+
+If you are the **Owner** of any team with an active paid subscription, you must cancel that subscription first. Go to the team's **Billing** page and cancel the subscription before proceeding.
+
+### What Happens to Your Teams
+
+Once the prerequisites are satisfied, deleting your account has the following effect on your teams:
+
+- **Owned teams** (teams where you hold the Owner role) that have no remaining projects or active subscriptions are **deleted automatically** along with your account.
+- **Non-owned teams** (teams where you are a member but not the Owner) are **not affected** — you are simply removed as a member and the team continues to exist.
+
+:::caution
+Account deletion is permanent and cannot be undone. Ensure you have exported or transferred any data you wish to keep before proceeding.
+:::

--- a/docs/distributing/Flow/account.mdx
+++ b/docs/distributing/Flow/account.mdx
@@ -7,17 +7,13 @@ sidebar_position: 5
 
 ## Account Settings
 
-To access your account settings in the <FlowLink /> dashboard, click your profile avatar or username in the top-right corner and select **Account Settings**. From here you can update your display name, email address, and manage security options such as connected OAuth providers.
+To access your account settings in the <FlowLink /> dashboard, click your profile avatar or username in the top-right corner and select **Account Settings**. From here you can update your display name, email address, and manage API keys.
 
 ## Deleting Your Account
 
 To permanently delete your account, navigate to **Account Settings** and scroll to the **Danger Zone** section, then click **Delete Account**.
 
-Before your account can be deleted, the following prerequisites must be met:
-
-### Remove Projects from Owned Teams
-
-If you are the **Owner** of any team that contains projects, you must delete all projects from those teams before your account can be deleted. Navigate to each team, open each project, and delete it from the project settings page.
+Before your account can be deleted, the following prerequisite must be met:
 
 ### Cancel Active Subscriptions
 
@@ -25,9 +21,9 @@ If you are the **Owner** of any team with an active paid subscription, you must 
 
 ### What Happens to Your Teams
 
-Once the prerequisites are satisfied, deleting your account has the following effect on your teams:
+When your account is deleted:
 
-- **Owned teams** (teams where you hold the Owner role) that have no remaining projects or active subscriptions are **deleted automatically** along with your account.
+- **Owned teams** (teams where you hold the Owner role) and all of their projects are **deleted automatically** — you do not need to manually remove projects beforehand.
 - **Non-owned teams** (teams where you are a member but not the Owner) are **not affected** — you are simply removed as a member and the team continues to exist.
 
 :::caution


### PR DESCRIPTION
## Summary

Adds a new Account Management page to the Velopack Flow documentation section.

## Changes

- \docs/distributing/Flow/account.mdx\ — new page covering:
  - How to navigate to Account Settings
  - Prerequisites for account deletion (delete projects from owned teams, cancel active subscriptions)
  - What happens to owned teams (auto-deleted) vs non-owned teams (user removed as member)
  - Caution admonition that deletion is permanent